### PR TITLE
Fix sqlparse dependency to >= 0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'patchy',
         'PyYAML',
         'six',
-        'sqlparse',
+        'sqlparse>=0.2.0',
     ],
     license='MIT',
     zip_safe=False,


### PR DESCRIPTION
The parsed format changed a bit from the 0.1 series, we require the new one.