### PR TITLE
Enable setting custom path for performance files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 Pending release
 ---------------
 
+* The ``file_name`` argument to ``record()`` is now deprecated in favour of the
+  new ``path`` argument.  It will be removed in a future release.
 * New release notes go here
 
 1.0.4 (2016-10-23)

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ Tested with all combinations of:
 API
 ===
 
-``record(file_name=None, record_name=None)``
---------------------------------------------
+``record(file_name=None, record_name=None, path=None)``
+-------------------------------------------------------
 
 Return a context manager that will be used for a single performance test.
 `file_name` is the name of the performance file to be used, and `record_name`
@@ -74,6 +74,8 @@ stack inspection to find that test case, and set `file_name` to the name of the
 file containing that class with `.py` replaced by `.perf.yml`, and
 `record_name` will be named after the test case + name, plus an optional
 counter if you invoke `record` multiple times inside the same test method.
+Additionnaly, `path` may be used to store performance files in a specific
+directory, relative to the test file.
 
 Whilst open, the context manager tracks all DB queries on all connections, and
 all cache operations on all defined caches. It names the connection/cache in

--- a/README.rst
+++ b/README.rst
@@ -67,15 +67,18 @@ API
 -------------------------------------------------------
 
 Return a context manager that will be used for a single performance test.
-`file_name` is the name of the performance file to be used, and `record_name`
+`path` is the name of the performance file to be used, and `record_name`
 is the name of the record inside that file to use. If either of these names is
-`None`, the code assumes you are inside a Django `TestCase` and uses magic
-stack inspection to find that test case, and set `file_name` to the name of the
-file containing that class with `.py` replaced by `.perf.yml`, and
-`record_name` will be named after the test case + name, plus an optional
-counter if you invoke `record` multiple times inside the same test method.
-Additionnaly, `path` may be used to store performance files in a specific
-directory, relative to the test file.
+`None`, or if `path` ends with a forward slash, the code assumes you are inside
+a Django `TestCase` and uses magic stack inspection to find that test case, and
+use the name of the file containing that class with `.py` replaced by
+`.perf.yml` as a file name, and `record_name` will be named after the test case
++ name, plus an optional counter if you invoke `record` multiple times inside
+the same test method. When `path` ends with a forward slash, it will be used as
+a directory name to store performance files into.
+
+The `file_name` argument is deprecated in favour of `path` and will be removed
+in a future release.
 
 Whilst open, the context manager tracks all DB queries on all connections, and
 all cache operations on all defined caches. It names the connection/cache in

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
 from threading import local
 
 from django.core.cache import DEFAULT_CACHE_ALIAS
@@ -15,7 +16,7 @@ from .yaml import KVFile
 record_current = local()
 
 
-def record(file_name=None, record_name=None):
+def record(file_name=None, record_name=None, path=None):
     test_details = current_test()
 
     if file_name is None:
@@ -24,6 +25,13 @@ def record(file_name=None, record_name=None):
             file_name = file_name[:-len('.py')] + '.perf.yml'
         else:
             file_name += '.perf.yml'
+
+    if path is not None:
+        directory = os.path.join(os.path.dirname(test_details.file_path), path)
+        if not os.path.exists(directory):
+            os.mkdir(directory)
+
+        file_name = os.path.join(directory, os.path.basename(file_name))
 
     if record_name is None:
         if test_details.class_name:
@@ -101,5 +109,5 @@ class TestCaseMixin(object):
     Adds record_performance() method to TestCase class it's mixed into
     for easy import-free use.
     """
-    def record_performance(self, file_name=None, record_name=None):
-        return record(file_name=file_name, record_name=record_name)
+    def record_performance(self, file_name=None, record_name=None, path=None):
+        return record(file_name=file_name, record_name=record_name, path=path)

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -1,3 +1,5 @@
+FileNameTests.test_default_filename:
+- cache|get: foo
 RecordTests.test_multiple_cache_ops:
 - cache|set: foo
 - cache|second|get_many:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -137,19 +137,16 @@ class FileNameTests(TestCase):
         os.path.basename(__file__).replace('.py', '.perf.yml')
     )
 
-    @classmethod
-    def setUpClass(cls):
-        super(FileNameTests, cls).setUpClass()
-        cls.ensure_no_file()
+    def setUp(self):
+        super(FileNameTests, self).setUp()
+        self.ensure_no_file()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.ensure_no_file()
-        super(FileNameTests, cls).tearDownClass()
+    def tearDown(self):
+        self.ensure_no_file()
+        super(FileNameTests, self).tearDown()
 
-    @classmethod
-    def ensure_no_file(cls):
-        for name in (cls.custom_perf_name, cls.custom_path_perf_name):
+    def ensure_no_file(self):
+        for name in (self.custom_perf_name, self.custom_path_perf_name):
             try:
                 os.unlink(name)
             except OSError as exc:
@@ -157,7 +154,7 @@ class FileNameTests(TestCase):
                     raise
 
         try:
-            os.rmdir(os.path.dirname(cls.custom_path_perf_name))
+            os.rmdir(os.path.dirname(self.custom_path_perf_name))
         except OSError as exc:
             if exc.errno != errno.ENOENT:
                 raise
@@ -169,13 +166,13 @@ class FileNameTests(TestCase):
         assert(os.path.exists(self.default_perf_name))
 
     def test_custom_filename(self):
-        with record(file_name='custom.perf.yml'):
+        with record(path='custom.perf.yml'):
             caches['default'].get('foo')
 
         assert(os.path.exists(self.custom_perf_name))
 
-    def test_custom_abs_path(self):
-        with record(path='performance_tests'):
+    def test_custom_path(self):
+        with record(path='performance_tests/'):
             caches['default'].get('foo')
 
         assert(os.path.exists(self.custom_path_perf_name))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,3 +125,57 @@ class TestCaseMixinTests(TestCaseMixin, TestCase):
         perf_name = __file__.replace('.py', '.file_name.perf.yml')
         with self.record_performance(file_name=perf_name):
             caches['default'].get('foo')
+
+
+class FileNameTests(TestCase):
+
+    default_perf_name = __file__.replace('.py', '.perf.yml')
+    custom_perf_name = 'custom.perf.yml'
+    custom_path_perf_name = os.path.join(
+        os.path.dirname(__file__),
+        'performance_tests',
+        os.path.basename(__file__).replace('.py', '.perf.yml')
+    )
+
+    @classmethod
+    def setUpClass(cls):
+        super(FileNameTests, cls).setUpClass()
+        cls.ensure_no_file()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.ensure_no_file()
+        super(FileNameTests, cls).tearDownClass()
+
+    @classmethod
+    def ensure_no_file(cls):
+        for name in (cls.custom_perf_name, cls.custom_path_perf_name):
+            try:
+                os.unlink(name)
+            except OSError as exc:
+                if exc.errno != errno.ENOENT:
+                    raise
+
+        try:
+            os.rmdir(os.path.dirname(cls.custom_path_perf_name))
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
+
+    def test_default_filename(self):
+        with record():
+            caches['default'].get('foo')
+
+        assert(os.path.exists(self.default_perf_name))
+
+    def test_custom_filename(self):
+        with record(file_name='custom.perf.yml'):
+            caches['default'].get('foo')
+
+        assert(os.path.exists(self.custom_perf_name))
+
+    def test_custom_abs_path(self):
+        with record(path='performance_tests'):
+            caches['default'].get('foo')
+
+        assert(os.path.exists(self.custom_path_perf_name))


### PR DESCRIPTION
This PR enables setting a custom path for performance files.

Usage:
```python
with record(path='performance_files'):
    # ...

with self.record_performance(path='performance_files'):
    # ...
```

Includes tests & documentation.