### PR TITLE
Fix automatic filenames for tests in `.pyc` files

### DIFF
--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -22,6 +22,8 @@ def record(file_name=None, record_name=None):
         file_name = test_details.file_path
         if file_name.endswith('.py'):
             file_name = file_name[:-len('.py')] + '.perf.yml'
+        elif file_name.endswith('.pyc'):
+            file_name = file_name[:-len('.pyc')] + '.perf.yml'
         else:
             file_name += '.perf.yml'
 


### PR DESCRIPTION
When running tests multiple times in the same environment, runs 2+ will have __file__ end with '.pyc'.  This PR allows using the same performance record file in both cases. Fixes #28 .