### PR TITLE
Show diff when assertion fails

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending release
 
 * New release notes go here
 * Fix django session keys not being fingerprinted.
+* Display record diff when changed.
 
 1.1.0 (2016-10-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,8 @@ gathered. If the file ``file_name`` doesn't exist, or doesn't contain data for
 the specific ``record_name``, it will be created and saved and the test will
 pass with no assertions. However if the record **does** exist inside the file,
 the collected record will be compared with the original one, and if different,
-an ``AssertionError`` will be raised. This currently uses a plain message, but
-if you're using `pytest <http://pytest.org/>`_ its assertion rewriting will be
-used and make it look pretty.
+an ``AssertionError`` will be raised and show what changed since the original
+record.
 
 Example:
 

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -10,7 +10,7 @@ from django.db import DEFAULT_DB_ALIAS
 
 from .cache import AllCacheRecorder
 from .db import AllDBRecorder
-from .utils import current_test
+from .utils import current_test, record_diff
 from .yaml import KVFile
 
 
@@ -112,7 +112,10 @@ class PerformanceRecorder(object):
         orig_record = self.records_file.get(self.record_name, None)
 
         if orig_record is not None:
-            assert self.record == orig_record, "Performance record did not match for {}".format(self.record_name)
+            assert self.record == orig_record, "Performance record did not match for {}\n{}".format(
+                self.record_name,
+                record_diff(orig_record, self.record)
+            )
 
         self.records_file.set_and_save(self.record_name, self.record)
 

--- a/django_perf_rec/utils.py
+++ b/django_perf_rec/utils.py
@@ -1,6 +1,7 @@
 # -*- coding:utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import difflib
 import inspect
 from collections import namedtuple
 
@@ -64,3 +65,13 @@ def sorted_names(names):
         sorted_names = ['default'] + sorted_names
 
     return sorted_names
+
+
+def record_diff(old, new):
+    """
+    Generate a human-readable diff of two performance records.
+    """
+    return '\n'.join(difflib.ndiff(
+        ['%s: %s' % (k, v) for op in old for k, v in op.items()],
+        ['%s: %s' % (k, v) for op in new for k, v in op.items()]
+    ))

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -33,3 +33,5 @@ custom:
 - cache|get: foo
 other:
 - cache|get: foo
+test_diff:
+- cache|get: foo

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,6 +78,17 @@ class RecordTests(TestCase):
 
         assert 'Performance record did not match' in six.text_type(excinfo.value)
 
+    def test_diff(self):
+        with record(record_name='test_diff'):
+            caches['default'].get('foo')
+
+        with pytest.raises(AssertionError) as excinfo:
+            with record(record_name='test_diff'):
+                caches['default'].get('bar')
+
+        assert '- cache|get: foo' in six.text_type(excinfo.value)
+        assert '+ cache|get: bar' in six.text_type(excinfo.value)
+
     def test_path_pointing_to_filename(self):
         with temporary_path('custom.perf.yml'):
 


### PR DESCRIPTION
This PR adds diff display to the assertion message (using difflib, somewhat close to what `unittest.TestCase.assertSequenceEqual` does, but without any size limits).