### PR TITLE
Don't use new diff code on pytest

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Pending release
 
 * New release notes go here
 * Fix django session keys not being fingerprinted.
-* Show diff when records don't match.
+* Show diff when records don't match (when not on pytest).
 
 1.1.0 (2016-10-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,9 @@ gathered. If the file ``file_name`` doesn't exist, or doesn't contain data for
 the specific ``record_name``, it will be created and saved and the test will
 pass with no assertions. However if the record **does** exist inside the file,
 the collected record will be compared with the original one, and if different,
-an ``AssertionError`` will be raised and show what changed since the original
-record.
+an ``AssertionError`` will be raised. When running on pytest, this will use its
+fancy assertion rewriting; in other test runners/uses the full diff will be
+attached to the message.
 
 Example:
 

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -8,6 +8,7 @@ from threading import local
 from django.core.cache import DEFAULT_CACHE_ALIAS
 from django.db import DEFAULT_DB_ALIAS
 
+from . import pytest_plugin
 from .cache import AllCacheRecorder
 from .db import AllDBRecorder
 from .utils import current_test, record_diff
@@ -112,10 +113,14 @@ class PerformanceRecorder(object):
         orig_record = self.records_file.get(self.record_name, None)
 
         if orig_record is not None:
-            assert self.record == orig_record, "Performance record did not match for {}\n{}".format(
-                self.record_name,
-                record_diff(orig_record, self.record)
+            msg = "Performance record did not match for {}".format(
+                self.record_name
             )
+            if not pytest_plugin.in_pytest:
+                msg += '\n{}'.format(
+                    record_diff(orig_record, self.record)
+                )
+            assert self.record == orig_record, msg
 
         self.records_file.set_and_save(self.record_name, self.record)
 

--- a/django_perf_rec/pytest_plugin.py
+++ b/django_perf_rec/pytest_plugin.py
@@ -1,0 +1,9 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+in_pytest = False
+
+
+def pytest_configure(config):
+    global in_pytest
+    in_pytest = True

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
     license='MIT',
     zip_safe=False,
     keywords='Django',
+    entry_points={
+        'pytest11': ['django_perf_rec = django_perf_rec.pytest_plugin'],
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django :: 1.8',

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,20 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.test import SimpleTestCase
+
+from django_perf_rec import pytest_plugin
+
+from .utils import pretend_not_under_pytest
+
+
+class PytestPluginTests(SimpleTestCase):
+
+    def test_in_pytest(self):
+        # We always run our tests in pytest
+        assert pytest_plugin.in_pytest
+
+    def test_in_pytest_pretend(self):
+        # The test helper should work to ignore it
+        with pretend_not_under_pytest():
+            assert not pytest_plugin.in_pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ import shutil
 from contextlib import contextmanager
 
 from django.db import connections
+from django_perf_rec import pytest_plugin
 
 
 def run_query(alias, sql, params=None):
@@ -30,3 +31,13 @@ def ensure_path_does_not_exist(path):
         except OSError as exc:
             if exc.errno != errno.ENOENT:
                 raise
+
+
+@contextmanager
+def pretend_not_under_pytest():
+    orig = pytest_plugin.in_pytest
+    pytest_plugin.in_pytest = False
+    try:
+        yield
+    finally:
+        pytest_plugin.in_pytest = orig


### PR DESCRIPTION
Follow up to #35.

Pytest's assertion rewriting is normally clearer and has several options for display
with the different levels of verbosity from its `-v` flag. We shouldn't display the
whole diff ourselves on pytest, we can rely on this behaviour.

This makes django-perf-rec officially a pytest plugin.