### PR TITLE
Allow passing TestDetails to record

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Pending release
 ---------------
 
 * New release notes go here
+* Added argument to pass custom TestDetails to ``record``
 
 2.0.1 (2017-03-02)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ Pending release
 ---------------
 
 * New release notes go here
-* Added argument to pass custom TestDetails to ``record``
+* Added argument to pass custom ``TestDetails`` to ``record``
 
 2.0.1 (2017-03-02)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,8 @@ Tested with all combinations of:
 API
 ===
 
-``record(record_name=None, path=None)``
----------------------------------------
+``record(record_name=None, path=None, test_details=None)``
+----------------------------------------------------------
 
 Return a context manager that will be used for a single performance test.
 
@@ -86,6 +86,12 @@ If left as ``None``, the code assumes you are inside a Django ``TestCase`` and
 uses magic stack inspection to find that test case, and uses a name based upon
 the test case name + the test method name + an optional counter if you invoke
 ``record()`` multiple times inside the same test method.
+
+``test_details`` normally django_perf_rec finds details about the current test
+by inspecting the call stack. Sometimes this is not possible, for example when
+using a pytest fixture to automatically record tests. In this case it is
+possible to manually create a ``TestDetails`` object that contains all the
+information that ``record()`` needs.
 
 Whilst open, the context manager tracks all DB queries on all connections, and
 all cache operations on all defined caches. It names the connection/cache in
@@ -143,6 +149,14 @@ Example:
         def test_special_method(self):
             with self.record_performance():
                 list(Author.objects.special_method())
+
+``TestDetails(file_path, class_name, test_name)``
+-------------------------------------------------
+
+``file_path`` the absolute path of the file that contains the test.
+``class_name`` the class that contains the test, this can be ``None`` if
+the test is not part of any class.
+``test_name`` the name of the actual test that is being run.
 
 Settings
 ========

--- a/django_perf_rec/__init__.py
+++ b/django_perf_rec/__init__.py
@@ -17,6 +17,6 @@ if pytest is not None:
     else:
         pytest.register_assert_rewrite('django_perf_rec.api')
 
-from .api import TestCaseMixin, record  # noqa: F401
+from .api import TestCaseMixin, record, TestDetails  # noqa: F401
 
 __version__ = '2.0.1'

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -21,8 +21,9 @@ record_current = local()
 
 
 @kwargs_only
-def record(record_name=None, path=None):
-    test_details = current_test()
+def record(record_name=None, path=None, test_details=None):
+    if test_details is None:
+        test_details = current_test()
 
     if path is None or path.endswith('/'):
         file_name = test_details.file_path

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -12,7 +12,7 @@ from .cache import AllCacheRecorder
 from .db import AllDBRecorder
 from .functional import kwargs_only
 from .settings import perf_rec_settings
-from .utils import current_test, record_diff
+from .utils import current_test, record_diff, TestDetails
 
 from .yaml import KVFile
 

--- a/django_perf_rec/api.py
+++ b/django_perf_rec/api.py
@@ -12,7 +12,8 @@ from .cache import AllCacheRecorder
 from .db import AllDBRecorder
 from .functional import kwargs_only
 from .settings import perf_rec_settings
-from .utils import current_test, record_diff, TestDetails
+from .utils import TestDetails  # noqa: F401
+from .utils import current_test, record_diff
 
 from .yaml import KVFile
 

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -2,6 +2,8 @@ FileNameTests.test_default_filename:
 - cache|get: foo
 RecordPathTests.test_default_filename:
 - cache|get: foo
+RecordTests.test_custom_test_details:
+- db: 'SELECT #'
 RecordTests.test_delete_on_cascade_called_twice:
 - db: DELETE FROM "testapp_book" WHERE "testapp_book"."author_id" IN (#)
 - db: DELETE FROM "testapp_award" WHERE "testapp_award"."author_id" IN (#)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from django.test import TestCase, override_settings
 from django_perf_rec import TestCaseMixin, record
 from testapp.models import Author
 
+from django_perf_rec.utils import current_test
 from .utils import pretend_not_under_pytest, run_query, temporary_path
 
 FILE_DIR = os.path.dirname(__file__)
@@ -136,6 +137,11 @@ class RecordTests(TestCase):
                 'test_api.perf.yml',
             )
             assert os.path.exists(full_path)
+
+    def test_custom_test_details(self):
+        test_details = current_test()
+        with record(test_details=test_details):
+            run_query('default', 'SELECT 1337')
 
     @override_settings(PERF_REC={'MODE': 'once'})
     def test_mode_once(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,7 +140,12 @@ class RecordTests(TestCase):
             assert os.path.exists(full_path)
 
     def test_custom_test_details(self):
-        test_details = current_test()
+        from django_perf_rec import TestDetails
+        test_details = TestDetails(
+            file_path=os.path.dirname(os.path.abspath(__file__)),
+            class_name='RecordTests',
+            test_name='test_custom_test_details'
+        )
         with record(test_details=test_details):
             run_query('default', 'SELECT 1337')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,6 @@ from django.db.models.functions import Upper
 from django.test import TestCase, override_settings
 
 from django_perf_rec import TestCaseMixin, record
-from django_perf_rec.utils import current_test
 
 from testapp.models import Author
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,7 +142,7 @@ class RecordTests(TestCase):
     def test_custom_test_details(self):
         from django_perf_rec import TestDetails
         test_details = TestDetails(
-            file_path=os.path.dirname(os.path.abspath(__file__)),
+            file_path=os.path.abspath(__file__),
             class_name='RecordTests',
             test_name='test_custom_test_details'
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,9 +11,10 @@ from django.db.models.functions import Upper
 from django.test import TestCase, override_settings
 
 from django_perf_rec import TestCaseMixin, record
+from django_perf_rec.utils import current_test
+
 from testapp.models import Author
 
-from django_perf_rec.utils import current_test
 from .utils import pretend_not_under_pytest, run_query, temporary_path
 
 FILE_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
I want to add a pytest fixture to my project that automatically records performance for my tests. When a pytest fixture is used the current frame stack doesn't contain the actual test that is being run and thus the `current_test()` function in utils.py is not able to create a `TestDetails` object. But pytest fixtures can receive a FixtureRequest object that does contain this information. I want to be able to create a `TestDetails` object myself that I pass to `record`. This PR fixes this.

My pytest fixture:
```python
@pytest.fixture(autouse=True)
def record_performance(request):
    td = TestDetails(
        file_path=request.fspath.strpath,
        class_name=request.cls.__name__ if request.cls is not None else None,
        test_name=request.function.__name__
    )
    with django_perf_rec.record(test_details=td):
        yield
```

Btw I get multilinter errors with `Imports are incorrectly sorted.` when I run tox locally, without my changes:
```
ERROR:   py27-codestyle: commands failed
ERROR:   py36-codestyle: commands failed
```
