### PR TITLE
Swap test_details for get_perf_path() and get_record_name()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,9 @@ Pending release
 ---------------
 
 * New release notes go here
-* Added argument to pass custom ``TestDetails`` to ``record()``
+* Exposed the automatic naming logic used in ``record()`` in two new functions
+  ``get_perf_path()`` and ``get_record_name()``, in order to ease creation of
+  test records from calls outside of tests.
 
 2.0.1 (2017-03-02)
 ------------------

--- a/django_perf_rec/__init__.py
+++ b/django_perf_rec/__init__.py
@@ -17,6 +17,6 @@ if pytest is not None:
     else:
         pytest.register_assert_rewrite('django_perf_rec.api')
 
-from .api import TestCaseMixin, record, TestDetails  # noqa: F401
+from .api import TestCaseMixin, get_record_name, get_perf_path, record  # noqa: F401
 
 __version__ = '2.0.1'

--- a/tests/test_api.file_name.perf.yml
+++ b/tests/test_api.file_name.perf.yml
@@ -1,2 +1,4 @@
 TestCaseMixinTests.test_record_performance_file_name:
 - cache|get: foo
+null:
+- cache|get: foo

--- a/tests/test_api.perf.yml
+++ b/tests/test_api.perf.yml
@@ -2,8 +2,6 @@ FileNameTests.test_default_filename:
 - cache|get: foo
 RecordPathTests.test_default_filename:
 - cache|get: foo
-RecordTests.test_custom_test_details:
-- db: 'SELECT #'
 RecordTests.test_delete_on_cascade_called_twice:
 - db: DELETE FROM "testapp_book" WHERE "testapp_book"."author_id" IN (#)
 - db: DELETE FROM "testapp_award" WHERE "testapp_award"."author_id" IN (#)
@@ -42,3 +40,8 @@ other:
 - cache|get: foo
 test_diff:
 - cache|get: foo
+null:
+- db: DELETE FROM "testapp_book" WHERE "testapp_book"."author_id" IN (#)
+- db: DELETE FROM "testapp_award" WHERE "testapp_award"."author_id" IN (#)
+- db: DELETE FROM "testapp_contract_author" WHERE "testapp_contract_author"."author_id" IN (#)
+- db: DELETE FROM "testapp_author" WHERE "testapp_author"."id" IN (#)

--- a/tests/test_pytest_fixture_usage.perf.yml
+++ b/tests/test_pytest_fixture_usage.perf.yml
@@ -1,0 +1,2 @@
+test_simple:
+- db: 'SELECT #'

--- a/tests/test_pytest_fixture_usage.py
+++ b/tests/test_pytest_fixture_usage.py
@@ -1,0 +1,24 @@
+# -*- coding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from django_perf_rec import get_perf_path, get_record_name, record
+
+from .utils import run_query
+
+
+@pytest.fixture
+def record_performance_build_name(request):
+    record_name = get_record_name(
+        class_name=request.cls.__name__ if request.cls is not None else None,
+        test_name=request.function.__name__,
+    )
+    path = get_perf_path(file_path=request.fspath.strpath)
+    with record(record_name=record_name, path=path):
+        yield
+
+
+@pytest.mark.django_db
+def test_simple(record_performance_build_name):
+    run_query('default', 'SELECT 1337')


### PR DESCRIPTION
This is a cleaner API and it leads to no problems with overrides of `path` or `record_name`. It also makes the separated functions easier to test.

I've also added a test with a pytest fixture as an example of what can be done with this.