### PR TITLE
Erase volatile part of PG cursor name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending release
 
 * New release notes go here
 * Use ``kwargs-only`` library rather than vendored copy.
+* Erase volatile part of PostgreSQL cursor name.
 
 2.1.0 (2017-05-29)
 ------------------

--- a/django_perf_rec/sql.py
+++ b/django_perf_rec/sql.py
@@ -54,6 +54,10 @@ def sql_recursively_simplify(node):
             node.tokens[6].tokens[0].value = '`#`'
             return
 
+    # Erase volatile part of PG cursor name
+    if node.tokens[0].value.startswith('"_django_curs_'):
+        node.tokens[0].value = '"_django_curs_#"'
+
     for i, token in enumerate(node.tokens):
         ttype = getattr(token, 'ttype', None)
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -53,6 +53,13 @@ def test_update():
     )
 
 
+def test_declare_cursor():
+    assert (
+        sql_fingerprint('DECLARE "_django_curs_140239496394496_1300" NO SCROLL CURSOR WITHOUT') ==
+        'DECLARE "_django_curs_#" NO SCROLL CURSOR WITHOUT'
+    )
+
+
 def test_savepoint():
     assert (
         sql_fingerprint("SAVEPOINT `s140323809662784_x54`") ==


### PR DESCRIPTION
With PG, we can have a Declaration Cursor in SQL generated. (here : https://github.com/django/django/blob/a862af383969ade774f6b0fa1d331bc87b188b89/tests/backends/postgresql/test_server_side_cursors.py#L40 , is the django test fort that). 

An example : 
``` 
db: DECLARE "_django_curs_140239496394496_1300" NO SCROLL CURSOR WITHOUT HOLD FOR SELECT DISTINCT ... FROM 
```

But cursor's name are volatile and so yaml record is never the same that record in test. This PR replace the volatile part  by a #. 